### PR TITLE
Add/assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,14 @@ Unlike standard actions, this action just uses variables from the environment.
 | PULL_REQUEST_FROM_BRANCH | if a branch isn't found in your GitHub payload, use this branch | false | |
 | PULL_REQUEST_BODY | the body for the pull request | false | |
 | PULL REQUEST_TITLE | the title for the pull request | false | |
-| PULL REQUEST_DRAFT | should this be a draft PR? | false | false |
+| PULL REQUEST_DRAFT | should this be a draft PR? | false | unset |
+| MAINTAINER_CANT_MODIFY | Do not allow the maintainer to modify the PR | false | unset |
 
-All booleans should be lowercase.
+For `PULL_REQUEST_DRAFT` and `MAINTAINER_CAN_MODIFY`, these are treated as environment
+booleans. If they are defined in the environment, they trigger the "true" condition. E.g.,:
+
+ - Define `MAINTAINER_CANT_MODIFY` if you don't want the maintainer to be able to modify the pull request.
+ - Define `PULL_REQUEST_DRAFT` if you want the PR to be a draft.
 
 The `GITHUB_TOKEN` secret is required to interact and authenticate with the GitHub API to open
 the pull request. The example is [deployed here](https://github.com/vsoch/pull-request-action-example) with an example opened (and merged) [pull request here](https://github.com/vsoch/pull-request-action-example/pull/1) if needed.

--- a/README.md
+++ b/README.md
@@ -42,12 +42,17 @@ Unlike standard actions, this action just uses variables from the environment.
 | PULL REQUEST_TITLE | the title for the pull request | false | |
 | PULL REQUEST_DRAFT | should this be a draft PR? | false | unset |
 | MAINTAINER_CANT_MODIFY | Do not allow the maintainer to modify the PR | false | unset |
+| PULL_REQUEST_ASSIGNEES | A list (string with spaces) of users to assign | false | unset |
 
 For `PULL_REQUEST_DRAFT` and `MAINTAINER_CAN_MODIFY`, these are treated as environment
 booleans. If they are defined in the environment, they trigger the "true" condition. E.g.,:
 
  - Define `MAINTAINER_CANT_MODIFY` if you don't want the maintainer to be able to modify the pull request.
  - Define `PULL_REQUEST_DRAFT` if you want the PR to be a draft.
+
+For `PULL_REQUEST_ASSIGNEES`, you can provide a string of one or more GitHub usernames to
+assign to the issue. Note that only users with push access can add assigness to 
+an issue or PR, they are ignored otherwise.
 
 The `GITHUB_TOKEN` secret is required to interact and authenticate with the GitHub API to open
 the pull request. The example is [deployed here](https://github.com/vsoch/pull-request-action-example) with an example opened (and merged) [pull request here](https://github.com/vsoch/pull-request-action-example/pull/1) if needed.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Unlike standard actions, this action just uses variables from the environment.
 | MAINTAINER_CANT_MODIFY | Do not allow the maintainer to modify the PR | false | unset |
 | PULL_REQUEST_ASSIGNEES | A list (string with spaces) of users to assign | false | unset |
 
-For `PULL_REQUEST_DRAFT` and `MAINTAINER_CAN_MODIFY`, these are treated as environment
+For `PULL_REQUEST_DRAFT` and `MAINTAINER_CANT_MODIFY`, these are treated as environment
 booleans. If they are defined in the environment, they trigger the "true" condition. E.g.,:
 
  - Define `MAINTAINER_CANT_MODIFY` if you don't want the maintainer to be able to modify the pull request.

--- a/examples/assignees-example.yml
+++ b/examples/assignees-example.yml
@@ -1,0 +1,17 @@
+name: Pull Request on Branch Push
+on:
+  push:
+    branches-ignore:
+      - devel
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@add/assignees
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: "update/"
+          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_ASSIGNEES: vsoch

--- a/examples/assignees-example.yml
+++ b/examples/assignees-example.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: pull-request-action
-        uses: vsoch/pull-request-action@add/assignees
+        uses: vsoch/pull-request-action@1.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_PREFIX: "update/"

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -76,7 +76,7 @@ create_pull_request() {
         # If there are assignees and we were successful to open, assigm them to it
         if [[ "${ASSIGNEES}" != "" ]] && [[ "${RETVAL}" == "0" ]]; then
 
-            echo "${REPONSE}"
+            echo "${RESPONSE}"
             NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.number')
             printf "Number opened for PR is ${NUMBER}\n"
             printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -86,9 +86,11 @@ create_pull_request() {
 
             # POST /repos/:owner/:repo/issues/:issue_number/assignees
             DATA="{\"assignees\":[${ASSIGNEES}]}"
+            echo "${DATA}"
             ASSIGNEES_URL="${ISSUE_URL}/${NUMBER}/assignees"
             curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${ASSIGNEES_URL}
             printf "$?\n"
+            exit 1;
         fi
     fi
 }

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -70,6 +70,8 @@ create_pull_request() {
         DATA="{\"title\":${TITLE}, \"body\":${BODY}, \"base\":${TARGET}, \"head\":${SOURCE}, \"draft\":${DRAFT}, \"maintainer_can_modify\":${MODIFY}}"
         printf "curl --user ${GITHUB_ACTOR} -X POST --data ${DATA} ${PULLS_URL}\n"
         RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${PULLS_URL})
+        RETVAL=$?
+        printf "Pull request return code: ${RETVAL}\n"
         NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.[] | .number')
         printf "Number opened for PR is ${NUMBER}\n"
 
@@ -80,8 +82,8 @@ create_pull_request() {
             # POST /repos/:owner/:repo/issues/:issue_number/assignees
             DATA="{\"assignees\":\"${ASSIGNEES}\"}"
             ASSIGNEES_URL="${ISSUE_URL}/${NUMBER}/assignees"
-            curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${ASSIGNEES_URL})
-            echo $?
+            curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${ASSIGNEES_URL}
+            printf "$?\n"
         fi
     fi
 }

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -37,7 +37,7 @@ check_events_json() {
 
     if [[ ! -f "${GITHUB_EVENT_PATH}" ]]; then
         printf "Cannot find Github events file at ${GITHUB_EVENT_PATH}\n";
-        exit 1;
+        exit 1
     fi
     printf "Found ${GITHUB_EVENT_PATH}\n";
 
@@ -80,9 +80,8 @@ create_pull_request() {
             NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.number')
             printf "Number opened for PR is ${NUMBER}\n"
 
-            # Remove trailing slashes
-            ASSIGNEES="${ASSIGNEES%\"}"
-            ASSIGNEES="${ASSIGNEES#\"}"
+            # Remove leading and trailing quotes
+            ASSIGNEES=$(echo "$ASSIGNEES" | sed -e 's/^"//' -e 's/"$//')
 
             # Parse assignees into a list            
             ASSIGNEES=$(echo $ASSIGNEES | sed -e 's/\(\w*\)/,"\1"/g' | cut -d , -f 2-)
@@ -94,7 +93,6 @@ create_pull_request() {
             ASSIGNEES_URL="${ISSUE_URL}/${NUMBER}/assignees"
             curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${ASSIGNEES_URL}
             printf "$?\n"
-            exit 1;
         fi
     fi
 }

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -79,11 +79,13 @@ create_pull_request() {
             echo "${RESPONSE}"
             NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.number')
             printf "Number opened for PR is ${NUMBER}\n"
+
+            # Parse assignees into a list
+            ASSIGNEES=$(echo $ASSIGNEES | sed -e 's/\(\w*\)/,"\1"/g' | cut -d , -f 2-)
             printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"
 
-
             # POST /repos/:owner/:repo/issues/:issue_number/assignees
-            DATA="{\"assignees\":\"${ASSIGNEES}\"}"
+            DATA="{\"assignees\":[${ASSIGNEES}]}"
             ASSIGNEES_URL="${ISSUE_URL}/${NUMBER}/assignees"
             curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${ASSIGNEES_URL}
             printf "$?\n"

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -77,7 +77,7 @@ create_pull_request() {
         # If there are assignees and we were successful to open, assigm them to it
         if [[ "${ASSIGNEES}" != "" ]] && [[ "${RETVAL}" == "0" ]]; then
 
-            NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.[] | .number')
+            NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.number')
             printf "Number opened for PR is ${NUMBER}\n"
             printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"
 

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -72,7 +72,6 @@ create_pull_request() {
         RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${PULLS_URL})
         RETVAL=$?
         printf "Pull request return code: ${RETVAL}\n"
-        echo ${RESPONSE}
 
         # If there are assignees and we were successful to open, assigm them to it
         if [[ "${ASSIGNEES}" != "" ]] && [[ "${RETVAL}" == "0" ]]; then

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -76,6 +76,7 @@ create_pull_request() {
         # If there are assignees and we were successful to open, assigm them to it
         if [[ "${ASSIGNEES}" != "" ]] && [[ "${RETVAL}" == "0" ]]; then
 
+            echo "${REPONSE}"
             NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.number')
             printf "Number opened for PR is ${NUMBER}\n"
             printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -72,12 +72,15 @@ create_pull_request() {
         RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" --user "${GITHUB_ACTOR}" -X POST --data "${DATA}" ${PULLS_URL})
         RETVAL=$?
         printf "Pull request return code: ${RETVAL}\n"
-        NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.[] | .number')
-        printf "Number opened for PR is ${NUMBER}\n"
+        echo ${RESPONSE}
 
-        # If there are assignees, assigm them to it
-        if [[ "${ASSIGNEES}" != "" ]]; then
+        # If there are assignees and we were successful to open, assigm them to it
+        if [[ "${ASSIGNEES}" != "" ]] && [[ "${RETVAL}" == "0" ]]; then
+
+            NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.[] | .number')
+            printf "Number opened for PR is ${NUMBER}\n"
             printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"
+
 
             # POST /repos/:owner/:repo/issues/:issue_number/assignees
             DATA="{\"assignees\":\"${ASSIGNEES}\"}"
@@ -168,14 +171,14 @@ main () {
             # Pull request body (optional)
             if [ -z "${PULL_REQUEST_BODY}" ]; then
                 echo "No pull request body is set, will use default."
-                PULL_REQUEST_BODY="This is an automated pull request to update the container collection ${BRANCH}"
+                PULL_REQUEST_BODY="This is an automated pull request to update from branch ${BRANCH}"
             fi
             printf "Pull request body is ${PULL_REQUEST_BODY}\n"
 
             # Pull request title (optional)
             if [ -z "${PULL_REQUEST_TITLE}" ]; then
                 printf "No pull request title is set, will use default.\n"
-                PULL_REQUEST_TITLE="Update container ${BRANCH}"
+                PULL_REQUEST_TITLE="Update from ${BRANCH}"
             fi
             printf "Pull request title is ${PULL_REQUEST_TITLE}\n"
 

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -80,7 +80,11 @@ create_pull_request() {
             NUMBER=$(echo "${RESPONSE}" | jq --raw-output '.number')
             printf "Number opened for PR is ${NUMBER}\n"
 
-            # Parse assignees into a list
+            # Remove trailing slashes
+            ASSIGNEES="${ASSIGNEES%\"}"
+            ASSIGNEES="${ASSIGNEES#\"}"
+
+            # Parse assignees into a list            
             ASSIGNEES=$(echo $ASSIGNEES | sed -e 's/\(\w*\)/,"\1"/g' | cut -d , -f 2-)
             printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"
 


### PR DESCRIPTION
This pull request will add an ability to assign someone to a pull request to address #19. An example recipe is provided in the examples folder, shown running [here](https://github.com/vsoch/pull-request-action-example/runs/517726152?check_suite_focus=true) to open the pull request [here](https://github.com/vsoch/pull-request-action-example/pull/13). This will close #19.  A basic example to test this branch:

```
name: Pull Request on Branch Push
on: [push]
jobs:
  auto-pull-request:
    name: PullRequestAction
    runs-on: ubuntu-latest
    steps:
      - name: pull-request-action
        uses: vsoch/pull-request-action@add/assignees
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          BRANCH_PREFIX: "update/"
          PULL_REQUEST_BRANCH: "master"
          PULL_REQUEST_ASSIGNEES: vsoch
```