### PR TITLE
Add/reviewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# CHANGELOG
+
+This is a manually generated log to track changes to the repository for each release. 
+Each section should include general headers such as **Implemented enhancements** 
+and **Merged pull requests**. All closed issued and bug fixes should be 
+represented by the pull requests that fixed them. Critical items to know are:
+
+ - renamed commands
+ - deprecated / removed commands
+ - changed defaults
+ - backward incompatible changes
+
+
+Versions correspond with GitHub releases that can be referenced with @ using actions.
+
+## [master](https://github.com/vsoch/pull-request-action/tree/master) (master)
+  - added support for reviewer (individual and team) assignments (1.0.4)
+  - added support for maintainer can modify and assignees (1.0.3)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Unlike standard actions, this action just uses variables from the environment.
 | PULL_REQUEST_DRAFT | should this be a draft PR? | false | unset |
 | MAINTAINER_CANT_MODIFY | Do not allow the maintainer to modify the PR | false | unset |
 | PULL_REQUEST_ASSIGNEES | A list (string with spaces) of users to assign | false | unset |
+| PULL_REQUEST_REVIEWERS | A list (string with spaces) of users to assign review | false | unset |
+| PULL_REQUEST_TEAM_REVIEWERS | A list (string with spaces) of teams to assign review | false | unset |
 
 For `PULL_REQUEST_DRAFT` and `MAINTAINER_CANT_MODIFY`, these are treated as environment
 booleans. If they are defined in the environment, they trigger the "true" condition. E.g.,:
@@ -50,7 +52,8 @@ booleans. If they are defined in the environment, they trigger the "true" condit
  - Define `MAINTAINER_CANT_MODIFY` if you don't want the maintainer to be able to modify the pull request.
  - Define `PULL_REQUEST_DRAFT` if you want the PR to be a draft.
 
-For `PULL_REQUEST_ASSIGNEES`, you can provide a string of one or more GitHub usernames to
+For `PULL_REQUEST_ASSIGNEES`, `PULL_REQUEST_REVIEWERS`, and `PULL_REQUEST_TEAM_REVIEWERS` 
+you can provide a string of one or more GitHub usernames (or team names) to
 assign to the issue. Note that only users with push access can add assigness to 
 an issue or PR, they are ignored otherwise.
 

--- a/examples/reviewers-example.yml
+++ b/examples/reviewers-example.yml
@@ -1,0 +1,17 @@
+name: Pull Request on Branch Push
+on:
+  push:
+    branches-ignore:
+      - devel
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@1.0.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: "update/"
+          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_REVIEWERS: vsoch

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -84,7 +84,7 @@ create_pull_request() {
             printf "Number opened for PR is ${NUMBER}\n"
 
             # Assignees are defined
-            if [[ "$ASSIGNEES" != '""' ]; then
+            if [[ "$ASSIGNEES" != '""' ]]; then
 
                 # Remove leading and trailing quotes
                 ASSIGNEES=$(echo "$ASSIGNEES" | sed -e 's/^"//' -e 's/"$//')


### PR DESCRIPTION
This PR will add support to allow for assignment of an individual or a team to a pull request, and will close #25. A simple example is below:

```
name: Pull Request on Branch Push
on:
  push:
    branches-ignore:
      - devel
jobs:
  auto-pull-request:
    name: PullRequestAction
    runs-on: ubuntu-latest
    steps:
      - name: pull-request-action
        uses: vsoch/pull-request-action@add/reviewers
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          BRANCH_PREFIX: "update/"
          PULL_REQUEST_BRANCH: "master"
          PULL_REQUEST_REVIEWERS: vsoch
```
After merge and release, this will be version 1.0.4. The testing branch is this one, add/reviewers, as shown in the recipe above. The variable for team reviewers is `PULL_REQUEST_TEAM_REVIEWERS`.