### PR TITLE
Fix bug for parsing list of reviewers/assignees with "-"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.5
+        uses: vsoch/pull-request-action@1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_PREFIX: "update/"
@@ -106,7 +106,7 @@ jobs:
             PR_BRANCH_FROM=release-v$(cat VERSION)
             ::set-env name=PULL_REQUEST_FROM_BRANCH::${PR_BRANCH_FROM}
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.5
+        uses: vsoch/pull-request-action@1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_BRANCH: "master"

--- a/examples/outputs-example.yml
+++ b/examples/outputs-example.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: pull-request-action
         id: pull_request
-        uses: vsoch/pull-request-action@1.0.5
+        uses: vsoch/pull-request-action@1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_PREFIX: "update/"

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -98,7 +98,7 @@ create_pull_request() {
                 ASSIGNEES=$(echo "$ASSIGNEES" | sed -e 's/^"//' -e 's/"$//')
 
                 # Parse assignees into a list            
-                ASSIGNEES=$(echo $ASSIGNEES | sed -e 's/\(\w*\)/,"\1"/g' | cut -d , -f 2-)
+                ASSIGNEES=$(echo $ASSIGNEES | printf '"%s"\n' $ASSIGNEES|paste -sd, -)
                 printf "Attempting to assign ${ASSIGNEES} to ${PR} with number ${NUMBER}"
 
                 # POST /repos/:owner/:repo/issues/:issue_number/assignees
@@ -119,9 +119,9 @@ create_pull_request() {
                 printf "Found reviewers: ${REVIEWERS} and team reviewers: ${TEAM_REVIEWERS}\n"
 
                 REVIEWERS=$(echo "$REVIEWERS" | sed -e 's/^"//' -e 's/"$//')
-                REVIEWERS=$(echo $REVIEWERS | sed -e 's/\(\w*\)/,"\1"/g' | cut -d , -f 2-)
+                REVIEWERS=$(echo $REVIEWERS | printf '"%s"\n' $REVIEWERS|paste -sd, -)
                 TEAM_REVIEWERS=$(echo "$TEAM_REVIEWERS" | sed -e 's/^"//' -e 's/"$//')
-                TEAM_REVIEWERS=$(echo $TEAM_REVIEWERS | sed -e 's/\(\w*\)/,"\1"/g' | cut -d , -f 2-)
+                TEAM_REVIEWERS=$(echo $TEAM_REVIEWERS | printf '"%s"\n' $TEAM_REVIEWERS|paste -sd, -)
 
                 # If either is empty, don't include emty string (provide empty list)
                 if [[ "$REVIEWERS" == '""' ]]; then REVIEWERS=; fi


### PR DESCRIPTION
There is currently a bug, reported in #32, that will incorrectly parse a string of reviewers names with any dashes - the dashes are treated as spaces. This branch will fix the issue.

Signed-off-by: vsoch <vsochat@stanford.edu>