### PR TITLE
replacing set-env with new environment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Example workflows are provided in [examples](examples), and please contribute an
 examples that you might have to help other users! We will walk through a basic
 example here for a niche case. Let's say that we are opening a pull request on the release event. This would mean
 that the payload's branch variable would be null. We would need to define `PULL_REQUEST_FROM`. How would
-we do that? We can [set environment variables](https://help.github.com/en/actions/reference/development-tools-for-github-actions#set-an-environment-variable-set-env) for next steps. Here is an example:
+we do that? We can [set environment variables](https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files) for next steps. Here is an example:
 
 ```yaml
 name: Pull Request on Branch Push
@@ -107,7 +107,7 @@ jobs:
         run: |
             # do custom parsing of your code / date to derive a branch from
             PR_BRANCH_FROM=release-v$(cat VERSION)
-            ::set-env name=PULL_REQUEST_FROM_BRANCH::${PR_BRANCH_FROM}
+            export "PULL_REQUEST_FROM_BRANCH=${PR_BRANCH_FROM}" >> $GITHUB_ENV
       - name: pull-request-action
         uses: vsoch/pull-request-action@1.0.6
         env:

--- a/examples/branch-from-environment.yml
+++ b/examples/branch-from-environment.yml
@@ -40,7 +40,7 @@ jobs:
            git push origin "${BRANCH_FROM}"
         fi
         # Here is where we are setting the environment variable!
-        echo "::set-env name=PULL_REQUEST_FROM_BRANCH::${BRANCH_FROM}"
+        echo "PULL_REQUEST_FROM_BRANCH=${BRANCH_FROM}" >> $GITHUB_ENV
 
     - name: Open Pull Request
       uses: vsoch/pull-request-action@1.0.6

--- a/examples/custom-body-example.yml
+++ b/examples/custom-body-example.yml
@@ -1,0 +1,55 @@
+name: Hotfix Branch Pull Request
+on:
+  push:
+    branches-ignore:
+      - master
+      - production
+
+# See https://github.com/vsoch/pull-request-action/issues/47#issuecomment-707109132
+
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate branch name
+        uses: actions/github-script@v3
+        id: set-branch-name
+        with:
+          script: |
+            const capitalize = (name) => name.charAt(0).toUpperCase() + name.slice(1);
+            const emoji = context.payload.ref.startsWith("refs/heads/feature")
+              ? "✨ "
+              : context.payload.ref.startsWith("refs/heads/hotfix")
+              ? "🚑 "
+              : "";
+            return `${emoji}${capitalize(
+              context.payload.ref
+                .replace("refs/heads/", "")
+                .replace(/-/g, " ")
+                .replace("feature ", "")
+                .replace("hotfix ", "")
+            )}`;
+          result-encoding: string
+      - name: Set branch name
+        run: echo "PULL_REQUEST_TITLE=${{steps.set-branch-name.outputs.result}}" >> $GITHUB_ENV
+      - name: Generate PR body
+        uses: actions/github-script@v3
+        id: set-pr-body
+        with:
+          script: |
+            return `I'm opening this pull request for this branch, pushed by @${
+              context.payload.head_commit.author.username
+            } with ${context.payload.commits.length} commit${
+              context.payload.commits.length === 1 ? "" : "s"
+            }.`;
+          result-encoding: string
+      - name: Set PR body
+        run: echo "PULL_REQUEST_BODY=${{steps.set-pr-body.outputs.result}}" >> $GITHUB_ENV
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@1.0.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: "hotfix-"
+          PULL_REQUEST_BRANCH: "production"
+          PULL_REQUEST_REVIEWERS: "AnandChowdhary"

--- a/pull-request.py
+++ b/pull-request.py
@@ -41,6 +41,11 @@ def parse_into_list(values):
     return [x.strip() for x in values.split(" ")]
 
 
+def set_env(name, value):
+    """helper function to echo a key/value pair to the environement file"""
+    os.system('echo "%s=%s" >> $GITHUB_ENV' % (name, value))
+
+
 ################################################################################
 # Global Variables (we can't use GITHUB_ prefix)
 ################################################################################
@@ -76,7 +81,7 @@ def create_pull_request(
     data = {"base": target, "head": source, "body": body}
     print("Data for checking if pull request exists: %s" % data)
     response = requests.get(PULLS_URL, json=data)
-    
+
     # Case 1: 404 might warrant needing a token
     if response.status_code == 404:
         response = requests.get(PULLS_URL, json=data, headers=HEADERS)
@@ -132,13 +137,13 @@ def create_pull_request(
         number = response.get("number")
         html_url = response.get("html_url")
         print("Number opened for PR is %s" % number)
-        print("::set-env name=PULL_REQUEST_NUMBER::%s" % number)
+        set_env("PULL_REQUEST_NUMBER", number)
         print("::set-output name=pull_request_number::%s" % number)
-        print("::set-env name=PULL_REQUEST_RETURN_CODE::%s" % pull_request_return_code)
+        set_env("PULL_REQUEST_RETURN_CODE", pull_request_return_code)
         print(
             "::set-output name=pull_request_return_code::%s" % pull_request_return_code
         )
-        print("::set-env name=PULL_REQUEST_URL::%s" % html_url)
+        set_env("PULL_REQUEST_URL", html_url)
         print("::set-output name=pull_request_url::%s" % html_url)
 
         if assignees:
@@ -168,7 +173,7 @@ def create_pull_request(
             assignees_return_code = (
                 0 if response.status_code == 201 else response.status_code
             )
-            print("::set-env name=ASSIGNEES_RETURN_CODE::%s" % assignees_return_code)
+            set_env("ASSIGNEES_RETURN_CODE", assignees_return_code)
             print("::set-output name=assignees_return_code::%s" % assignees_return_code)
 
         if reviewers or team_reviewers:
@@ -206,7 +211,7 @@ def create_pull_request(
             print("::group::github reviewers response")
             print(response)
             print("::endgroup::github reviewers response")
-            print("::set-env name=REVIEWERS_RETURN_CODE::%s" % reviewers_return_code)
+            set_env("REVIEWERS_RETURN_CODE", reviewers_return_code)
             print("::set-output name=reviewers_return_code::%s" % reviewers_return_code)
             print("Add reviewers return code: %s" % reviewers_return_code)
 

--- a/pull-request.py
+++ b/pull-request.py
@@ -43,7 +43,10 @@ def parse_into_list(values):
 
 def set_env(name, value):
     """helper function to echo a key/value pair to the environement file"""
-    os.system('echo "%s=%s" >> $GITHUB_ENV' % (name, value))
+    environment_file_path = os.environ.get("GITHUB_ENV")
+
+    with open(environment_file_path, "a") as environment_file:
+        environment_file.write("%s=%s" % (name, value))
 
 
 ################################################################################


### PR DESCRIPTION
This is a suggested fix for the update to not use set-env. We probably don't need to push forward with it until users start gettig issues and have a good example to test with it.

Signed-off-by: vsoch <vsochat@stanford.edu>