### PR TITLE
PASS_IF_EXISTS option, to not error out when a matching PR already is open

### DIFF
--- a/pull-request.py
+++ b/pull-request.py
@@ -75,7 +75,7 @@ def create_pull_request(
     # Check if the branch already has a pull request open
     params = {"base": target, "head": source, "state": "open"}
     data = {"base": target, "head": source, "body": body}
-    print("Data for checking if pull request exists: %s" % data)
+    print("Params for checking if pull request exists: %s" % params)
     response = requests.get(PULLS_URL, params=params)
 
     # Case 1: 404 might warrant needing a token

--- a/pull-request.py
+++ b/pull-request.py
@@ -101,6 +101,7 @@ def create_pull_request(
                 if os.environ.get("PASS_IF_EXISTS"):
                     print("PASS_IF_EXISTS is set, exiting with success status.")
                     sys.exit(0)
+                break
 
     # Option 2: Open a new pull request
     if not is_open:


### PR DESCRIPTION
Added onto vsoch's, by putting the exit code in a different spot.

While in the area, I made the `params` used for the `get` different from the `data` used in the `post`, since the API signature is slightly different.

Tested it for my use case and it worked (didn't error whether matching PR already existed or not, and created a PR if not).