### PR TITLE
adding back assignees variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ represented by the pull requests that fixed them. Critical items to know are:
 Versions correspond with GitHub releases that can be referenced with @ using actions.
 
 ## [master](https://github.com/vsoch/pull-request-action/tree/master) (master)
+  - forgot to add assignees (1.0.15)
   - output and environment variables for PR number and return codes (1.0.5)
   - added support for reviewer (individual and team) assignments (1.0.4)
   - added support for maintainer can modify and assignees (1.0.3)

--- a/pull-request.py
+++ b/pull-request.py
@@ -188,11 +188,12 @@ def list_pull_requests(target, source):
     return response.json()
 
 
-def add_assignees(entry):
+def add_assignees(entry, assignees):
     """Given a pull request metadata (from create or update) add assignees
 
     Parameters:
-    entry (dict) : the pull request metadata
+    entry (dict)    : the pull request metadata
+    assignees (str) : comma separated assignees string set by action
     """
     # Remove leading and trailing quotes
     assignees = parse_into_list(assignees)
@@ -320,7 +321,7 @@ def create_pull_request(
 
     # If we have opened or updated, we can add assignees
     if response and assignees:
-        add_assignees(response)
+        add_assignees(response, assignees)
     if response and (reviewers or team_reviewers):
         add_reviewers(response, reviewers, team_reviewers)
 


### PR DESCRIPTION
There is currently a bug that I forgot to pass assignees to the function! This will close #64.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>