### PR TITLE
Respect docker proxy settings, if configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ LABEL "com.github.actions.description"="Create a pull request when a branch is c
 LABEL "com.github.actions.icon"="activity"
 LABEL "com.github.actions.color"="yellow"
 
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTPS_PROXY
+ENV NO_PROXY=$NO_PROXY
+
 RUN apk --no-cache add python3 py3-pip git bash && \
     pip3 install requests
 COPY pull-request.py /pull-request.py

--- a/README.md
+++ b/README.md
@@ -150,3 +150,6 @@ registry to update it.
 If the branch is already open for PR, it updates it. Take a look at [this example](https://github.com/singularityhub/registry-org/pull/8)
 for the pull request opened when we updated the previous GitHub syntax to the new yaml syntax. Although this
 doesn't describe the workflow above, it works equivalently in terms of the triggers.
+  
+### Proxy
+Building the docker container requires access to pypi.python.org/pypi. If you are running this action ob a self-hosted runner behind a proxy, you can configure the docker client to [flow proxy info to the container](https://docs.docker.com/network/proxy/#configure-the-docker-client). This action will respect the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` settings in `~/.docker/config.json`, if set.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ for the pull request opened when we updated the previous GitHub syntax to the ne
 doesn't describe the workflow above, it works equivalently in terms of the triggers.
   
 ### Proxy
-Building the docker container requires access to pypi.python.org/pypi. If you are running this action ob a self-hosted runner behind a proxy, you can configure the docker client to [flow proxy info to the container](https://docs.docker.com/network/proxy/#configure-the-docker-client). This action will respect the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` settings in `~/.docker/config.json`, if set.
+Building the docker container requires access to pypi.python.org/pypi. If you are running this action on a self-hosted runner behind a proxy, you can configure the docker client to [flow proxy info to the container](https://docs.docker.com/network/proxy/#configure-the-docker-client) or set create `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` [environment variables](https://docs.docker.com/network/proxy/#configure-the-docker-client) on the runner.


### PR DESCRIPTION
Updated action to respect HTTP and HTTPS proxy settings, if configured on the docker client. This allows the action to be run on self-hosted runners behind a proxy without affecting normal users.