### PR TITLE
[Chore] Provide token when getting 401 error

### DIFF
--- a/pull-request.py
+++ b/pull-request.py
@@ -239,7 +239,7 @@ def find_default_branch():
     response = requests.get(REPO_URL)
 
     # Case 1: 404 might need a token
-    if response.status_code == 404:
+    if response.status_code in [401, 404]:
         response = requests.get(REPO_URL, headers=HEADERS)
     if response.status_code != 200:
         abort_if_fail(response, "Unable to retrieve default branch")


### PR DESCRIPTION
Issue #87

In GHE, token is necessary when querying the repo API, When it fails, it returns 401 error. Will need to specify the token in this case.

Before the fix:
```
pull-request-action on  fix/ghe-get-401-error [!] via 🐍 v2.7.18 via 💎 v2.7.0
❯ python3 pull-request.py
==========================================================================
START: Running Pull Request on Branch Update Action!
Found ${GITHUB_EVENT_PATH} at /Users/hokho/workspace/pull-request-action
Branch prefix is
No branch prefix is set, all branches will be used.
Unable to retrieve default branch: 401: Unauthorized
 {'message': 'Must authenticate to access this API.', 'documentation_url': 'https://docs.github.com/enterprise/3.3/rest'}
```

After the fix:
```
pull-request-action on  fix/ghe-get-401-error [!] via 🐍 v2.7.18 via 💎 v2.7.0
❯ python3 pull-request.py
==========================================================================
START: Running Pull Request on Branch Update Action!
Found ${GITHUB_EVENT_PATH} at /Users/hokho/workspace/pull-request-action
Branch prefix is
No branch prefix is set, all branches will be used.
Found default branch: develop
Pull requests will go to develop
```