### PR TITLE
fix: construct ASSIGNEES_URL to the correct url

### DIFF
--- a/pull-request.py
+++ b/pull-request.py
@@ -208,7 +208,7 @@ def add_assignees(entry, assignees):
 
     # POST /repos/:owner/:repo/issues/:issue_number/assignees
     data = {"assignees": assignees}
-    ASSIGNEES_URL = "%s/%s/assignees" % (ISSUE_URL, number)
+    ASSIGNEES_URL = "%s/issues/%s/assignees" % (REPO_URL, number)
     response = requests.post(ASSIGNEES_URL, json=data, headers=HEADERS)
     if response.status_code != 201:
         abort_if_fail(response, "Unable to create assignees")


### PR DESCRIPTION
**The issue**: The action fails to assign assignees to the created PR**

**Logs sample**:
```
START: Running Pull Request on Branch Update Action!
Found ${GITHUB_EVENT_PATH} at /github/workflow/event.json
Branch prefix is 
No branch prefix is set, all branches will be used.
Pull requests will go to main
PULL_REQUEST_DRAFT set to a value: created PRs will be draft PRs.
No preference for maintainer being able to modify: default is true.
PULL_REQUEST_ASSIGNEES is set, HasanKhatib
.
.
github response: 'assignees_url': '[https://api.github.com/repos/ingka-group-digital/resolutions/assignees{/user}](https://api.github.com/repos/ingka-group-digital/resolutions/assignees%7B/user%7D)'
```


**The fix:**

- Based on [GitHub REST API](https://docs.github.com/en/rest/issues/assignees?apiVersion=2022-11-28#add-assignees-to-an-issue), use the correct endpoint to add assignees to an issue `/repos/:owner/:repo/issues/:issue_number/assignees`

This has been fixed in the add_assignees function.

